### PR TITLE
Perplexity fix

### DIFF
--- a/agent_baselines/solvers/sqa/formatted_perplexity.py
+++ b/agent_baselines/solvers/sqa/formatted_perplexity.py
@@ -1,17 +1,41 @@
 import logging
 
 from inspect_ai.solver import Solver, chain, solver
+from inspect_ai.model import ChatMessageAssistant
 
 from agent_baselines.solvers.sqa.format_solver import format_solver
 from agent_baselines.solvers.sqa.perplexity_base import perplexity_solver
 
 logger = logging.getLogger(__name__)
 
+@solver
+def add_perplexity_references() -> Solver:
+
+    async def solve(state, generate):
+        m = state.messages[-1]
+        if not isinstance(m, ChatMessageAssistant):
+            raise ValueError("The last message must be from the assistant.")
+
+        citations = m.content[-1].citations
+
+        references_str = '\n\n## References\n\nEach reference below is in the format "[citation ID] {title} ({url})". Use `title` as the `excerpt`'
+        for idx, citation in enumerate(citations):
+            title, url = citation.title, citation.url
+            references_str += f'\n[{idx + 1}] {title} ({url})'
+
+        state.messages.append(ChatMessageAssistant(content=m.text + references_str))
+        return state
+
+    return solve
 
 @solver
 def formatted_solver(
     system_prompt: str | None = None,
     search_context_size: str | None = None,
+    reasoning_effort: str = "",
+    search_mode: str = "",
+    require_snippets: bool = True,
+    scorer_model: str = "google/gemini-2.5-flash-preview-05-20"
 ) -> Solver:
     chainlist = [
         perplexity_solver(
@@ -19,7 +43,10 @@ def formatted_solver(
             prompt_template="{prompt_without_formatting_instructions}",
             system_message=system_prompt,
             search_context_size=search_context_size,
+            reasoning_effort=reasoning_effort,
+            search_mode=search_mode
         ),
-        format_solver("google/gemini-2.5-flash-preview-05-20"),
+        add_perplexity_references(),
+        format_solver(scorer_model, require_snippets=require_snippets),
     ]
     return chain(chainlist)

--- a/agent_baselines/solvers/sqa/perplexity_base.py
+++ b/agent_baselines/solvers/sqa/perplexity_base.py
@@ -51,9 +51,10 @@ def perplexity_solver(
     system_message: str | None = None,
     use_structured_decoding: bool = False,
     search_context_size: str | None = None,
-    search_mode: str = "academic",
+    search_mode: str = "",
     # Date format can be flexible (e.g., '3/1/2025', 'March 1, 2025').
     search_before_date_filter: str | None = None,
+    reasoning_effort: str = "high",
 ) -> Solver:
     # Verify that we have a PerplexityAPI model
     model = get_model()
@@ -82,7 +83,10 @@ def perplexity_solver(
                 "search_context_size": search_context_size
             }
 
-        extra_body["search_mode"] = search_mode
+        if search_mode:
+            extra_body["search_mode"] = search_mode
+        if reasoning_effort:
+            extra_body["reasoning_effort"] = reasoning_effort
 
         if search_before_date_filter is not None:
             extra_body["search_before_date_filter"] = search_before_date_filter


### PR DESCRIPTION
Re-adding the perplexity fixes because I forgot to merge it 🥲

**SQA Command:**

```
uv run inspect eval /Users/nishantbalepur/Desktop/Repositories/agent-baselines/.venv/lib/python3.13/site-packages/astabench/evals/sqa/task.py@sqa \
    --display plain \
    -T with_search_tools=false \
    -T simplified_eval=true \
    -T assess_jointly=true \
    --max-connections 16 \
    --max-samples 4 \
    --model ${generation_model} \
    --solver agent_baselines/solvers/sqa/formatted_perplexity.py@formatted_solver \
    -T sentence_wise_cit_eval=false \
    -T all_at_once=true \
    -T scorer_model='google/gemini-2.5-flash-preview-05-20' \
    -T split=${split} \
    -S search_context_size=high \
    -S require_snippets=false \
    -S reasoning_effort=high
```

**Results:**
```
global_avg/mean: 0.673  global_avg/stderr: 0.00455  ingredient_recall/mean: 0.924  ingredient_recall/stderr: 0.0107  answer_precision/mean: 0.94  answer_precision/stderr: 0.0108
citation_precision/mean: 0.462  citation_precision/stderr: 0.00338  citation_recall/mean: 0.367  citation_recall/stderr: 0.00751
```

---

**LitQA2 Command:**
```
uv run inspect eval /Users/nishantbalepur/Desktop/Repositories/agent-baselines/.venv/lib/python3.13/site-packages/astabench/evals/labbench/litqa2/task.py@litqa2_test \
        --display plain \
        --solver agent_baselines/solvers/sqa/perplexity_base.py@perplexity_solver \
        --model ${generation_model} \
        -T with_search_tools=false \
        -T with_native_search_tools=false \
        -S search_context_size=high
```

**LitQA2 Results:**
```
score_litqa2/precision: 0.9  score_litqa2/coverage: 0.8  is_correct/accuracy: 0.72  is_correct/stderr: 0.0522
```

Very similar to the results here: https://github.com/allenai/asta-bench/pull/92