### PR TITLE
solvers/__init__.py: guard astabench imports so submodules can be used standalone

### DIFF
--- a/agent_baselines/solvers/__init__.py
+++ b/agent_baselines/solvers/__init__.py
@@ -1,4 +1,13 @@
-from astabench.util.model import normalize_model_name, record_model_usage_with_inspect
+# Re-exports that pull in astabench are guarded so submodules without
+# astabench dependencies (e.g. agent_baselines.solvers.inspect_swe) can
+# be imported in environments where astabench isn't installed.
+try:
+    from astabench.util.model import (  # noqa: F401
+        normalize_model_name,
+        record_model_usage_with_inspect,
+    )
+    from .futurehouse import futurehouse_solver  # noqa: F401
+except ImportError:
+    pass
 
-from .futurehouse import futurehouse_solver
-from .llm import llm_with_prompt
+from .llm import llm_with_prompt  # noqa: F401


### PR DESCRIPTION
## Summary

`agent_baselines/solvers/__init__.py` imports `astabench.util.model` at module top, so importing any submodule (e.g. `agent_baselines.solvers.inspect_swe.agent`) requires `astabench` to be installed in the venv.

Some solvers under `solvers/` are independent of `astabench` (the inspect_swe wrapper, `llm_with_prompt`). Wrapping the astabench-touching imports in `try/except ImportError` lets those solvers be used from minimal environments that don't pull in astabench's transitive deps (e.g. an inspect_swe-only setup that needs newer `litellm` than `astabench==0.5.x` pins).

No behavior change when astabench is installed.

## Test plan

- [x] Without astabench installed, `python -c "from agent_baselines.solvers.inspect_swe.agent import inspect_swe_solver"` succeeds. (On main it raises `ModuleNotFoundError: No module named 'astabench'` while loading `solvers/__init__.py`.)
- [x] With astabench installed, all four re-exports (`futurehouse_solver`, `llm_with_prompt`, `normalize_model_name`, `record_model_usage_with_inspect`) import the same as on main.