### PR TITLE
youcom solvers: prefer YDC_API_KEY env var (keep YOUCOM_API_KEY fallback)

### DIFF
--- a/agent_baselines/solvers/sqa/formatted_youcom.py
+++ b/agent_baselines/solvers/sqa/formatted_youcom.py
@@ -10,7 +10,8 @@ from agent_baselines.solvers.youcom import query_youcom
 
 logger = logging.getLogger(__name__)
 
-YOUCOM_API_KEY = os.environ["YOUCOM_API_KEY"]
+# YDC_API_KEY is You.com's canonical env var; YOUCOM_API_KEY kept as a fallback.
+YOUCOM_API_KEY = os.environ.get("YDC_API_KEY") or os.environ["YOUCOM_API_KEY"]
 
 
 @solver

--- a/agent_baselines/solvers/youcom.py
+++ b/agent_baselines/solvers/youcom.py
@@ -8,7 +8,8 @@ from inspect_ai.model import ChatMessageAssistant
 from inspect_ai.solver import Generate, Solver, TaskState, solver
 
 logger = logging.getLogger(__name__)
-YOUCOM_API_KEY = os.environ["YOUCOM_API_KEY"]
+# YDC_API_KEY is You.com's canonical env var; YOUCOM_API_KEY kept as a fallback.
+YOUCOM_API_KEY = os.environ.get("YDC_API_KEY") or os.environ["YOUCOM_API_KEY"]
 
 
 async def query_youcom(


### PR DESCRIPTION
## What

Make the You.com solvers prefer the canonical `YDC_API_KEY` environment variable, keeping `YOUCOM_API_KEY` as a backward-compatible fallback.

## Why

`YDC_API_KEY` is You.com's canonical API key env var — used by You.com's own docs/SDK and the LangChain/CrewAI/DSPy integrations. The solvers currently require `YOUCOM_API_KEY`, which is inconsistent with the rest of the ecosystem.

## Change

In `agent_baselines/solvers/youcom.py` and `agent_baselines/solvers/sqa/formatted_youcom.py`:

```python
YOUCOM_API_KEY = os.environ.get("YDC_API_KEY") or os.environ["YOUCOM_API_KEY"]
```

`YDC_API_KEY` is used when set; otherwise `YOUCOM_API_KEY` is honored exactly as before (and still raises if neither is present).

Part of a cross-ecosystem standardization effort: youdotcom-oss/integration-tracking#30
