### PR TITLE
inspect-swe: lower inspect_ai floor 0.3.249 → 0.3.233

### DIFF
--- a/solvers/inspect-swe/pyproject.toml
+++ b/solvers/inspect-swe/pyproject.toml
@@ -11,12 +11,14 @@ dependencies = [
     # results that are Pydantic models (e.g. list[ContentText] from real
     # MCP servers). Older versions fail bridged MCP calls with
     # "Object of type ContentText is not JSON serializable".
-    # >=0.3.249 additionally lets the Anthropic sandbox bridge accept a
+    # >=0.3.233 additionally lets the Anthropic sandbox bridge accept a
     # system-role message in `messages[]` (folds it into ChatMessageSystem
-    # in messages_from_anthropic_input). Current Claude Code emits such a
-    # message; 0.3.220 raised `RuntimeError: Unexpected message role: system`
-    # and interrupted the arm mid-sample.
-    "inspect_ai>=0.3.249",
+    # in messages_from_anthropic_input, commit 8829d740 / #4095). Current
+    # Claude Code emits such a message; 0.3.220 raised
+    # `RuntimeError: Unexpected message role: system` and interrupted the
+    # arm mid-sample. 0.3.233 is the tightest floor carrying both fixes;
+    # nothing above it (0.3.249 etc.) is required to run this arm.
+    "inspect_ai>=0.3.233",
     # >=0.2.54 contains the per-invocation bridge port allocation
     # (claude_code ACP) that unblocks parallel evals — older versions
     # share a fixed port 13131 between concurrent samples and serialize.
@@ -33,8 +35,11 @@ astabench = ["astabench==0.5.3"]
 
 [tool.uv]
 default-groups = ["astabench"]
-# astabench==0.5.3 pins inspect_ai==0.3.203, but we need >=0.3.249 for
-# the bridged-MCP serialization fix and the Anthropic bridge system-role
-# fix. Override astabench's pin so the resolver picks a newer inspect_ai.
-# Public APIs astabench uses are stable across 0.3.203..0.3.249.
-override-dependencies = ["inspect_ai>=0.3.249"]
+# astabench==0.5.3 pins inspect_ai (==0.3.203 historically), but this arm
+# needs >=0.3.233 for the bridged-MCP list[ContentText] serialization fix
+# (0.3.220) and the Anthropic bridge system-role fix (0.3.233). Override so
+# the resolver can pick an inspect_ai that satisfies both, while still
+# letting astabench's own pin (once bumped to ==0.3.233, allenai/asta-bench#156)
+# land the exact version. Public APIs astabench uses are stable across
+# 0.3.203..0.3.233.
+override-dependencies = ["inspect_ai>=0.3.233"]

--- a/solvers/inspect-swe/pyproject.toml
+++ b/solvers/inspect-swe/pyproject.toml
@@ -17,31 +17,28 @@ dependencies = [
     # Claude Code emits such a message; 0.3.220 raised
     # `RuntimeError: Unexpected message role: system` and interrupted the
     # arm mid-sample.
-    # >=0.3.235 is additionally required by the inspect_swe cap below:
-    # inspect_swe 0.2.63 (the newest release compatible with a *released*
-    # inspect_ai — see the cap comment) declares `inspect-ai>=0.3.235` and
-    # uses install_skills/read_skills/model_event_sink, which land in
-    # 0.3.235. 0.3.235 is the tightest floor carrying all of the above;
-    # nothing higher (0.3.249 etc.) is required to run this arm, and staying
+    # 0.3.233 is the tightest floor carrying both fixes; nothing higher
+    # (0.3.249 etc.) is required to run this arm. Staying
     # below the additive-log-field releases (model_fallbacks@0.3.240,
     # turn_count@0.3.248) keeps the frozen 0.3.203 scorer able to read the
     # logs this arm writes.
-    "inspect_ai>=0.3.235",
+    "inspect_ai>=0.3.233",
     # >=0.2.54 contains the per-invocation bridge port allocation
     # (claude_code ACP) that unblocks parallel evals — older versions
     # share a fixed port 13131 between concurrent samples and serialize.
     # 0.2.52 introduced the ``opencode`` agent which the wrapper now
     # registers; older versions don't expose that constructor.
-    # <0.2.65 CAP: inspect_swe 0.2.65 started calling
-    # `sandbox_agent_bridge(..., checkpointer=cp)` (claude_code.py), but the
-    # `checkpointer=` kwarg exists in NO released inspect_ai — the latest
-    # release (0.3.249) rejects it with
-    # `TypeError: sandbox_agent_bridge() got an unexpected keyword argument
-    # 'checkpointer'`, which killed the baseline arm. inspect_swe 0.2.65/0.2.66
-    # target an unreleased dev inspect_ai. 0.2.63 is the newest release that
-    # runs against a released inspect_ai; cap here until inspect_ai ships the
-    # checkpointer bridge param and inspect_swe's floor catches up.
-    "inspect_swe>=0.2.54,<0.2.65",
+    # <0.2.60 CAP: the inspect_ai override below replaces inspect_swe's own
+    # inspect_ai floor. Leaving inspect_swe floating therefore paired 0.2.66
+    # (which declares inspect-ai>=0.3.244 and passes `checkpointer=` to
+    # sandbox_agent_bridge) with astabench's exact inspect_ai==0.3.233 pin.
+    # That incompatible pair killed the baseline arm with an unexpected
+    # `checkpointer` keyword. Versions 0.2.60 through 0.2.63 also declare an
+    # inspect_ai floor above the issue's tight 0.3.233 requirement. 0.2.59 is
+    # the newest release whose declared floor (>=0.3.232) supports 0.3.233,
+    # while retaining the per-invocation bridge and skills support this arm
+    # needs.
+    "inspect_swe>=0.2.54,<0.2.60",
 ]
 
 # ``astabench`` ships the public eval tasks (``astabench/litqa2_validation``
@@ -53,18 +50,17 @@ astabench = ["astabench==0.5.3"]
 [tool.uv]
 default-groups = ["astabench"]
 # astabench==0.5.3 pins inspect_ai (==0.3.203 historically), but this arm
-# needs >=0.3.235 for the bridged-MCP list[ContentText] serialization fix
-# (0.3.220), the Anthropic bridge system-role fix (0.3.233), and the
-# install_skills/read_skills/model_event_sink APIs inspect_swe 0.2.63 uses
-# (0.3.235). Override so the resolver can pick an inspect_ai that satisfies
+# needs >=0.3.233 for the bridged-MCP list[ContentText] serialization fix
+# (0.3.220) and the Anthropic bridge system-role fix (0.3.233). Override so
+# the resolver can pick an inspect_ai that satisfies
 # all of these, while still letting astabench's own pin (once bumped to
-# ==0.3.235, allenai/asta-bench#156) land the exact version. Public APIs
-# astabench uses are stable across 0.3.203..0.3.235.
+# ==0.3.233, allenai/asta-bench#156) land the exact version. Public APIs
+# astabench uses are stable across 0.3.203..0.3.233.
 #
-# inspect_ai>=0.3.235 refuses to construct the Anthropic model provider unless
+# inspect_ai>=0.3.233 refuses to construct the Anthropic model provider unless
 # `anthropic>=0.105.0` is installed (runtime check in its anthropic provider;
 # the floor is declared only under inspect's `dev` extra, so uv won't raise it
 # on its own and the lock otherwise stays on whatever anthropic it first
 # resolved — 0.97.0 here). Force the floor so the solve env satisfies the
 # provider that inspect-swe's Claude Code arm exercises.
-override-dependencies = ["inspect_ai>=0.3.235", "anthropic>=0.105.0"]
+override-dependencies = ["inspect_ai>=0.3.233", "anthropic>=0.105.0"]

--- a/solvers/inspect-swe/pyproject.toml
+++ b/solvers/inspect-swe/pyproject.toml
@@ -22,8 +22,7 @@ dependencies = [
     # below the additive-log-field releases (model_fallbacks@0.3.240,
     # turn_count@0.3.248) so the frozen 0.3.203 scorer can still read the
     # logs this arm writes. Without the cap the resolver floats to the
-    # newest inspect_ai (0.3.249), which both breaks that scorer and (via
-    # its AsyncBedrockOpenAI import) forces an openai>=2.40.0 floor.
+    # newest inspect_ai (0.3.249), which breaks that scorer.
     "inspect_ai>=0.3.233,<0.3.240",
     # >=0.2.54 contains the per-invocation bridge port allocation
     # (claude_code ACP) that unblocks parallel evals — older versions
@@ -68,7 +67,14 @@ default-groups = ["astabench"]
 #
 # The <0.3.240 cap mirrors the [project] dependency: it keeps the resolver
 # from floating past the frozen-scorer-safe window (see the inspect_ai note
-# above). It also means we do NOT need the openai>=2.40.0 floor that main
-# added for 0.3.249 — that AsyncBedrockOpenAI import isn't present below
-# 0.3.240.
-override-dependencies = ["inspect_ai>=0.3.233,<0.3.240", "anthropic>=0.105.0"]
+# above).
+#
+# inspect-ai 0.3.239 imports AsyncBedrockOpenAI from the OpenAI client; that
+# symbol was added in openai 2.40.0. Without this floor the AstaBench
+# dependency graph resolves openai 2.33.0 and task discovery fails before an
+# eval starts.
+override-dependencies = [
+    "inspect_ai>=0.3.233,<0.3.240",
+    "anthropic>=0.105.0",
+    "openai>=2.40.0",
+]

--- a/solvers/inspect-swe/pyproject.toml
+++ b/solvers/inspect-swe/pyproject.toml
@@ -42,4 +42,11 @@ default-groups = ["astabench"]
 # letting astabench's own pin (once bumped to ==0.3.233, allenai/asta-bench#156)
 # land the exact version. Public APIs astabench uses are stable across
 # 0.3.203..0.3.233.
-override-dependencies = ["inspect_ai>=0.3.233"]
+#
+# inspect_ai>=0.3.233 refuses to construct the Anthropic model provider unless
+# `anthropic>=0.105.0` is installed (runtime check in its anthropic provider;
+# the floor is declared only under inspect's `dev` extra, so uv won't raise it
+# on its own and the lock otherwise stays on whatever anthropic it first
+# resolved — 0.97.0 here). Force the floor so the solve env satisfies the
+# provider that inspect-swe's Claude Code arm exercises.
+override-dependencies = ["inspect_ai>=0.3.233", "anthropic>=0.105.0"]

--- a/solvers/inspect-swe/pyproject.toml
+++ b/solvers/inspect-swe/pyproject.toml
@@ -11,20 +11,37 @@ dependencies = [
     # results that are Pydantic models (e.g. list[ContentText] from real
     # MCP servers). Older versions fail bridged MCP calls with
     # "Object of type ContentText is not JSON serializable".
-    # >=0.3.233 additionally lets the Anthropic sandbox bridge accept a
-    # system-role message in `messages[]` (folds it into ChatMessageSystem
-    # in messages_from_anthropic_input, commit 8829d740 / #4095). Current
+    # >=0.3.233 lets the Anthropic sandbox bridge accept a system-role
+    # message in `messages[]` (folds it into ChatMessageSystem in
+    # messages_from_anthropic_input, commit 8829d740 / #4095). Current
     # Claude Code emits such a message; 0.3.220 raised
     # `RuntimeError: Unexpected message role: system` and interrupted the
-    # arm mid-sample. 0.3.233 is the tightest floor carrying both fixes;
-    # nothing above it (0.3.249 etc.) is required to run this arm.
-    "inspect_ai>=0.3.233",
+    # arm mid-sample.
+    # >=0.3.235 is additionally required by the inspect_swe cap below:
+    # inspect_swe 0.2.63 (the newest release compatible with a *released*
+    # inspect_ai — see the cap comment) declares `inspect-ai>=0.3.235` and
+    # uses install_skills/read_skills/model_event_sink, which land in
+    # 0.3.235. 0.3.235 is the tightest floor carrying all of the above;
+    # nothing higher (0.3.249 etc.) is required to run this arm, and staying
+    # below the additive-log-field releases (model_fallbacks@0.3.240,
+    # turn_count@0.3.248) keeps the frozen 0.3.203 scorer able to read the
+    # logs this arm writes.
+    "inspect_ai>=0.3.235",
     # >=0.2.54 contains the per-invocation bridge port allocation
     # (claude_code ACP) that unblocks parallel evals — older versions
     # share a fixed port 13131 between concurrent samples and serialize.
     # 0.2.52 introduced the ``opencode`` agent which the wrapper now
     # registers; older versions don't expose that constructor.
-    "inspect_swe>=0.2.54",
+    # <0.2.65 CAP: inspect_swe 0.2.65 started calling
+    # `sandbox_agent_bridge(..., checkpointer=cp)` (claude_code.py), but the
+    # `checkpointer=` kwarg exists in NO released inspect_ai — the latest
+    # release (0.3.249) rejects it with
+    # `TypeError: sandbox_agent_bridge() got an unexpected keyword argument
+    # 'checkpointer'`, which killed the baseline arm. inspect_swe 0.2.65/0.2.66
+    # target an unreleased dev inspect_ai. 0.2.63 is the newest release that
+    # runs against a released inspect_ai; cap here until inspect_ai ships the
+    # checkpointer bridge param and inspect_swe's floor catches up.
+    "inspect_swe>=0.2.54,<0.2.65",
 ]
 
 # ``astabench`` ships the public eval tasks (``astabench/litqa2_validation``
@@ -36,17 +53,18 @@ astabench = ["astabench==0.5.3"]
 [tool.uv]
 default-groups = ["astabench"]
 # astabench==0.5.3 pins inspect_ai (==0.3.203 historically), but this arm
-# needs >=0.3.233 for the bridged-MCP list[ContentText] serialization fix
-# (0.3.220) and the Anthropic bridge system-role fix (0.3.233). Override so
-# the resolver can pick an inspect_ai that satisfies both, while still
-# letting astabench's own pin (once bumped to ==0.3.233, allenai/asta-bench#156)
-# land the exact version. Public APIs astabench uses are stable across
-# 0.3.203..0.3.233.
+# needs >=0.3.235 for the bridged-MCP list[ContentText] serialization fix
+# (0.3.220), the Anthropic bridge system-role fix (0.3.233), and the
+# install_skills/read_skills/model_event_sink APIs inspect_swe 0.2.63 uses
+# (0.3.235). Override so the resolver can pick an inspect_ai that satisfies
+# all of these, while still letting astabench's own pin (once bumped to
+# ==0.3.235, allenai/asta-bench#156) land the exact version. Public APIs
+# astabench uses are stable across 0.3.203..0.3.235.
 #
-# inspect_ai>=0.3.233 refuses to construct the Anthropic model provider unless
+# inspect_ai>=0.3.235 refuses to construct the Anthropic model provider unless
 # `anthropic>=0.105.0` is installed (runtime check in its anthropic provider;
 # the floor is declared only under inspect's `dev` extra, so uv won't raise it
 # on its own and the lock otherwise stays on whatever anthropic it first
 # resolved — 0.97.0 here). Force the floor so the solve env satisfies the
 # provider that inspect-swe's Claude Code arm exercises.
-override-dependencies = ["inspect_ai>=0.3.233", "anthropic>=0.105.0"]
+override-dependencies = ["inspect_ai>=0.3.235", "anthropic>=0.105.0"]

--- a/solvers/inspect-swe/uv.lock
+++ b/solvers/inspect-swe/uv.lock
@@ -11,7 +11,7 @@ resolution-markers = [
 ]
 
 [manifest]
-overrides = [{ name = "inspect-ai", specifier = ">=0.3.249" }]
+overrides = [{ name = "inspect-ai", specifier = ">=0.3.233" }]
 
 [[package]]
 name = "agent-baselines-inspect-swe"
@@ -29,7 +29,7 @@ astabench = [
 
 [package.metadata]
 requires-dist = [
-    { name = "inspect-ai", specifier = ">=0.3.249" },
+    { name = "inspect-ai", specifier = ">=0.3.233" },
     { name = "inspect-swe", specifier = ">=0.2.54" },
 ]
 

--- a/solvers/inspect-swe/uv.lock
+++ b/solvers/inspect-swe/uv.lock
@@ -11,7 +11,10 @@ resolution-markers = [
 ]
 
 [manifest]
-overrides = [{ name = "inspect-ai", specifier = ">=0.3.233" }]
+overrides = [
+    { name = "anthropic", specifier = ">=0.105.0" },
+    { name = "inspect-ai", specifier = ">=0.3.233" },
+]
 
 [[package]]
 name = "agent-baselines-inspect-swe"
@@ -271,7 +274,7 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.97.0"
+version = "0.120.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -283,9 +286,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/14/93/f66ea8bfe39f2e6bb9da8e27fa5457ad2520e8f7612dfc547b17fad55c4d/anthropic-0.97.0.tar.gz", hash = "sha256:021e79fd8e21e90ad94dc5ba2bbbd8b1599f424f5b1fab6c06204009cab764be", size = 669502, upload-time = "2026-04-23T20:52:34.445Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/5c/3331da4fc009d448008a50c78d86cc929e8c937cd1442245ce3f80561c4e/anthropic-0.120.0.tar.gz", hash = "sha256:6ba6007dc9b00365b20f6101a6618f5196ac1ceef81512e4b5cc0e7436d4975d", size = 1008042, upload-time = "2026-07-24T16:32:52.384Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/53/b6/8e851369fa661ad0fef2ae6266bf3b7d52b78ccf011720058f4adaca59e2/anthropic-0.97.0-py3-none-any.whl", hash = "sha256:8a1a472dfabcfc0c52ff6a3eecf724ac7e07107a2f6e2367be55ceb42f5d5613", size = 662126, upload-time = "2026-04-23T20:52:32.377Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/8a/8522bdf809e1f95f0d9c936540987a3f6afba01d2921a2bf488dedf836a8/anthropic-0.120.0-py3-none-any.whl", hash = "sha256:591bd531563ec7b63a1e138f5c11f14cb94edda99623b349c2ce2ece8e08b8a5", size = 1022602, upload-time = "2026-07-24T16:32:50.506Z" },
 ]
 
 [[package]]

--- a/solvers/inspect-swe/uv.lock
+++ b/solvers/inspect-swe/uv.lock
@@ -13,7 +13,7 @@ resolution-markers = [
 [manifest]
 overrides = [
     { name = "anthropic", specifier = ">=0.105.0" },
-    { name = "inspect-ai", specifier = ">=0.3.235" },
+    { name = "inspect-ai", specifier = ">=0.3.233" },
 ]
 
 [[package]]
@@ -32,8 +32,8 @@ astabench = [
 
 [package.metadata]
 requires-dist = [
-    { name = "inspect-ai", specifier = ">=0.3.235" },
-    { name = "inspect-swe", specifier = ">=0.2.54,<0.2.65" },
+    { name = "inspect-ai", specifier = ">=0.3.233" },
+    { name = "inspect-swe", specifier = ">=0.2.54,<0.2.60" },
 ]
 
 [package.metadata.requires-dev]
@@ -1380,7 +1380,7 @@ wheels = [
 
 [[package]]
 name = "inspect-swe"
-version = "0.2.63"
+version = "0.2.59"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "agent-client-protocol" },
@@ -1394,9 +1394,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2a/0c/67e3b2eb35f170754f1f07d3834dcdfd21d4c16c76635ae72f052ab284c1/inspect_swe-0.2.63.tar.gz", hash = "sha256:6aa47f9d5da3f2139637a51662f7698b42645b1c70a61019585091c60501fa48", size = 94331, upload-time = "2026-06-10T17:37:35.333Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/f2/5304e82a1e779877436c7004c47818d032dd4cc70f3ee40d4d692aa7b271/inspect_swe-0.2.59.tar.gz", hash = "sha256:473d51c33fba01511edccf20d3a56f1265fa3b5210430232a76d99de8318c18a", size = 90996, upload-time = "2026-06-01T01:18:08.708Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ab/eb/0d9e81becac3bf98279f5172af13fa6ae7377fbed9a266a9e892f7bb9906/inspect_swe-0.2.63-py3-none-any.whl", hash = "sha256:9c34cf572a0aaee6fdbad23eccb1ea4c5b57d9e650e8a282db691cd63c965f61", size = 126922, upload-time = "2026-06-10T17:37:33.769Z" },
+    { url = "https://files.pythonhosted.org/packages/67/a2/49e0d76dafb891130035595771f13402776d112dec8cbccd4eedc8549b1b/inspect_swe-0.2.59-py3-none-any.whl", hash = "sha256:524bd2337eb480ffd0b90954d32d66589a7c55b5080e899c62dedd035a576341", size = 122956, upload-time = "2026-06-01T01:18:07.362Z" },
 ]
 
 [[package]]

--- a/solvers/inspect-swe/uv.lock
+++ b/solvers/inspect-swe/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
@@ -14,6 +14,7 @@ resolution-markers = [
 overrides = [
     { name = "anthropic", specifier = ">=0.105.0" },
     { name = "inspect-ai", specifier = ">=0.3.233,<0.3.240" },
+    { name = "openai", specifier = ">=2.40.0" },
 ]
 
 [[package]]
@@ -2299,7 +2300,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "2.33.0"
+version = "2.52.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2311,9 +2312,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f0/ee/d056c82f63c05f06baac0cffb4a90952d8274f90c49dfe244f20497b9bbd/openai-2.33.0.tar.gz", hash = "sha256:f850c435e2a4685bba3295bd54912dd26315d9c1b7733068186134d6e0599f9a", size = 693254, upload-time = "2026-04-28T14:04:42.428Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/4b/87a877fd987db5737e43e357ff968e2c04f21be54034507fb38de5e4af99/openai-2.52.1.tar.gz", hash = "sha256:d8f2bf9f0ec8104b171f3448e98baa59a41e26906cf53f5343346d0fa7924d98", size = 1098956, upload-time = "2026-08-03T17:16:38.561Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7d/32/37734d769bc8b42e4938785313cc05aade6cb0fa72479d3220a0d61a4e78/openai-2.33.0-py3-none-any.whl", hash = "sha256:03ac37d70e8c9e3a8124214e3afa785e2cbc12e627fbd98177a086ef2fd87ad5", size = 1162695, upload-time = "2026-04-28T14:04:40.482Z" },
+    { url = "https://files.pythonhosted.org/packages/05/7a/45d1786760bda9ac69365b40bb3f9827e40c90938e633de8716aaab864c6/openai-2.52.1-py3-none-any.whl", hash = "sha256:49cfd53cdddfd98eeca353ee8e1f02bdb66601b6f9e6bd6dc90c754accbea958", size = 1659571, upload-time = "2026-08-03T17:16:36.675Z" },
 ]
 
 [[package]]
@@ -4009,7 +4010,7 @@ name = "zipfile-zstd"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zstandard" },
+    { name = "zstandard", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f7/2a/2e0941bc0058d10ab37d8c578b94a19f611f6ae54f124140f2fb451f0932/zipfile-zstd-0.0.4.tar.gz", hash = "sha256:c1498e15b7922a3d1af0ea55df8b11b2af4e8f7e0e80e414e25d66899f7def89", size = 4603, upload-time = "2021-12-08T07:38:16.245Z" }
 wheels = [

--- a/solvers/inspect-swe/uv.lock
+++ b/solvers/inspect-swe/uv.lock
@@ -13,7 +13,7 @@ resolution-markers = [
 [manifest]
 overrides = [
     { name = "anthropic", specifier = ">=0.105.0" },
-    { name = "inspect-ai", specifier = ">=0.3.233" },
+    { name = "inspect-ai", specifier = ">=0.3.235" },
 ]
 
 [[package]]
@@ -32,8 +32,8 @@ astabench = [
 
 [package.metadata]
 requires-dist = [
-    { name = "inspect-ai", specifier = ">=0.3.233" },
-    { name = "inspect-swe", specifier = ">=0.2.54" },
+    { name = "inspect-ai", specifier = ">=0.3.235" },
+    { name = "inspect-swe", specifier = ">=0.2.54,<0.2.65" },
 ]
 
 [package.metadata.requires-dev]
@@ -1380,7 +1380,7 @@ wheels = [
 
 [[package]]
 name = "inspect-swe"
-version = "0.2.66"
+version = "0.2.63"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "agent-client-protocol" },
@@ -1394,9 +1394,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4c/54/b8797e61a264b5585e50367417caf1b2cf2116f05fd46b868fa384035d0e/inspect_swe-0.2.66.tar.gz", hash = "sha256:5136dbebdd645b6f4bae8bc42266d0e0d9f63d13a5126b6e51702730cea717f7", size = 96401, upload-time = "2026-07-14T19:38:24.507Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2a/0c/67e3b2eb35f170754f1f07d3834dcdfd21d4c16c76635ae72f052ab284c1/inspect_swe-0.2.63.tar.gz", hash = "sha256:6aa47f9d5da3f2139637a51662f7698b42645b1c70a61019585091c60501fa48", size = 94331, upload-time = "2026-06-10T17:37:35.333Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8a/68/804cac69406bc5721146c4bdbce2d6d5a05105c8acc2c471ea9a379ba7ad/inspect_swe-0.2.66-py3-none-any.whl", hash = "sha256:588f6fc6955e2bb7353a0d5c4fad3a7f04341e9467fde3bbde0baa24050b25c9", size = 129173, upload-time = "2026-07-14T19:38:23.065Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/eb/0d9e81becac3bf98279f5172af13fa6ae7377fbed9a266a9e892f7bb9906/inspect_swe-0.2.63-py3-none-any.whl", hash = "sha256:9c34cf572a0aaee6fdbad23eccb1ea4c5b57d9e650e8a282db691cd63c965f61", size = 126922, upload-time = "2026-06-10T17:37:33.769Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

- Lower the solve override from `inspect_ai>=0.3.249` to the tight required floor, `>=0.3.233`.
- Cap `inspect_swe>=0.2.54,<0.2.60` (resolves 0.2.59).
- Require `anthropic>=0.105.0` so the Inspect provider runtime check is satisfied.
- Regenerate the frozen solver lock.

## Why

`inspect_ai 0.3.233` is the first version carrying both fixes this arm needs: bridged-tool `list[ContentText]` serialization (0.3.220) and bridged Anthropic inline `role: system` handling (0.3.233).

The uv override replaces transitive declarations. Without the inspect-swe cap, it paired `inspect_swe 0.2.66` (which declares `inspect-ai>=0.3.244` and passes `checkpointer=` to the bridge) with AstaBench exact `inspect_ai==0.3.233`, causing the failed eval. Inspect-swe 0.2.59 is the newest release whose declared Inspect floor (`>=0.3.232`) admits 0.3.233 and it retains the per-invocation bridge and skills support required here.

This preserves the minimal Inspect bump approved in allenai/gas2own#346. Versions 0.2.60-0.2.63 would unnecessarily raise the Inspect floor; 0.2.65+ require the newer checkpoint bridge API.

## Validation

- Local uv overlay resolves exactly `inspect_ai 0.3.233` + `inspect_swe 0.2.59`.
- Claude Code solver imports under that pair; its bridge call does not pass the incompatible `checkpointer` keyword.
- CI is running.
- Full `improve-skills` solve→score validation is running as async job `gas2own-inspect-decouple-346-v4`.

Paired with allenai/asta-bench#156. Tracking: allenai/gas2own#346.