### PR TITLE
inspect-swe: refresh Anthropic SDK lock

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,4 +148,4 @@ smoke-solvers:
 	@$(TEST_RUN) ./scripts/smoke_solvers.sh $(SMOKE_SOLVERS)
 
 smoke-solvers-ci:
-	@$(TEST_RUN) ./scripts/smoke_solvers.sh react paper_finder
+	@$(TEST_RUN) ./scripts/smoke_solvers.sh react paper_finder inspect_swe

--- a/Makefile
+++ b/Makefile
@@ -148,4 +148,4 @@ smoke-solvers:
 	@$(TEST_RUN) ./scripts/smoke_solvers.sh $(SMOKE_SOLVERS)
 
 smoke-solvers-ci:
-	@$(TEST_RUN) ./scripts/smoke_solvers.sh react paper_finder inspect_swe
+	@$(TEST_RUN) ./scripts/smoke_solvers.sh react paper_finder inspect-swe

--- a/scripts/smoke_solvers.sh
+++ b/scripts/smoke_solvers.sh
@@ -67,6 +67,35 @@ print("agent_baselines:", getattr(agent_baselines, "__version__", "unknown"), li
 print("agent_baselines.solvers:", agent_baselines.solvers.__file__)
 print("astabench:", getattr(astabench, "__version__", "unknown"), astabench.__file__)
 print("inspect_ai:", getattr(inspect_ai, "__version__", "unknown"), inspect_ai.__file__)
+
+# Lock-coherence gate. inspect_ai enforces a minimum Anthropic SDK version at
+# provider *construction* — not through package metadata — so an internally
+# incoherent lock (inspect_ai bumped, anthropic left stale) sails past both
+# ``uv lock --check`` and the plain imports above, then fails only deep inside
+# an eval with "Anthropic API requires at least version X of package anthropic"
+# (allenai/gas2own#430). Construct the provider here so CI trips that gate in
+# seconds instead. Solvers whose env has no anthropic are skipped.
+try:
+    import anthropic
+except ImportError:
+    print("anthropic: not in this solver env; skipping provider-construction gate")
+else:
+    import os
+
+    os.environ.setdefault("ANTHROPIC_API_KEY", "sk-ant-smoke-placeholder-not-a-real-key")
+    from inspect_ai.model import get_model
+
+    try:
+        get_model("anthropic/claude-sonnet-4-6")
+    except Exception as exc:  # noqa: BLE001
+        message = str(exc)
+        # Only the version floor is a lock-coherence failure; a missing key or
+        # network hiccup means we got *past* the gate, which is all we assert.
+        if "at least version" in message or "Upgrade with" in message:
+            raise
+        print("anthropic provider: reached past version gate (non-version note:", message, ")")
+    else:
+        print("anthropic provider: constructs cleanly with anthropic", anthropic.__version__)
 PY
 done
 

--- a/solvers/inspect-swe/uv.lock
+++ b/solvers/inspect-swe/uv.lock
@@ -271,7 +271,7 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.97.0"
+version = "0.120.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -283,9 +283,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/14/93/f66ea8bfe39f2e6bb9da8e27fa5457ad2520e8f7612dfc547b17fad55c4d/anthropic-0.97.0.tar.gz", hash = "sha256:021e79fd8e21e90ad94dc5ba2bbbd8b1599f424f5b1fab6c06204009cab764be", size = 669502, upload-time = "2026-04-23T20:52:34.445Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/10/4ca013cb166f226bd89e0aeb0fcaff94f45ddf716d4925ce89475d3c587b/anthropic-0.120.2.tar.gz", hash = "sha256:9722efc10c27a30a69f5338ddacdb35bc6a64297a4e4ba729bf83af873d5fb3a", size = 1008421, upload-time = "2026-07-28T17:38:26.986Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/53/b6/8e851369fa661ad0fef2ae6266bf3b7d52b78ccf011720058f4adaca59e2/anthropic-0.97.0-py3-none-any.whl", hash = "sha256:8a1a472dfabcfc0c52ff6a3eecf724ac7e07107a2f6e2367be55ceb42f5d5613", size = 662126, upload-time = "2026-04-23T20:52:32.377Z" },
+    { url = "https://files.pythonhosted.org/packages/63/af/0f5db57b9397a0f3b7fc204cbef143401a7cadaf982330f97f1ce3d39f34/anthropic-0.120.2-py3-none-any.whl", hash = "sha256:0f0bc2b381dc0eb41c8d886b815d79c2041cd2374f83aed36f574b6dc9c579c1", size = 1022851, upload-time = "2026-07-28T17:38:25.466Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Refresh the frozen `inspect-swe` lock so `anthropic` moves from 0.97.0 to 0.120.2 while retaining `inspect-ai` 0.3.249.

`inspect-ai` 0.3.249 rejects Anthropic SDK versions below 0.105.0 at provider initialization, so the lock produced by #30 fails before eval sampling begins. The paired Asta skills benchmark tracked in allenai/gas2own#430 exposed the mismatch.

Bundle a regression guard so this class of skew is caught in CI: the solver smoke now constructs an Anthropic provider, and `inspect-swe` is included in the per-solver CI smoke set.

## Validation

- `uv lock --project solvers/inspect-swe --python 3.11 --check`
- `./scripts/smoke_solvers.sh inspect-swe`
- Frozen environment reports `anthropic=0.120.2`, `inspect_ai=0.3.249`, and successfully constructs `get_model("anthropic/claude-sonnet-4-6")`
- `bash -n scripts/smoke_solvers.sh`
- `git diff --check`

Tracked by allenai/gas2own#430.
