### PR TITLE
inspect-swe: allow provenance probes under sandbox load

### DIFF
--- a/agent_baselines/solvers/inspect_swe/agent.py
+++ b/agent_baselines/solvers/inspect_swe/agent.py
@@ -24,6 +24,12 @@ AgentName = Literal[
 ]
 AstaPlugin = Literal["asta", "asta-preview"]
 
+# Provenance probes run after the agent, when a many-sample eval can have
+# substantial concurrent sandbox load. Ten seconds proved too short for the
+# otherwise-trivial ``asta --version`` command in Cloud Batch, causing strict
+# runs to discard completed samples solely because the stamp timed out.
+_PROVENANCE_PROBE_TIMEOUT = 30
+
 
 class AgentSpec(NamedTuple):
     """Per-agent facts the wrapper needs in one place.
@@ -694,7 +700,11 @@ async def _stamp_asta_version(
 
     try:
         sbx = sandbox(sandbox_name) if sandbox_name else sandbox()
-        res = await sbx.exec(["asta", "--version"], timeout=10, user=sandbox_user)
+        res = await sbx.exec(
+            ["asta", "--version"],
+            timeout=_PROVENANCE_PROBE_TIMEOUT,
+            user=sandbox_user,
+        )
     except Exception as e:
         _record_repro_warning(
             state, f"asta_version probe raised {e!r}; slot left unset"

--- a/tests/solvers/test_inspect_swe_solver.py
+++ b/tests/solvers/test_inspect_swe_solver.py
@@ -983,9 +983,12 @@ class TestVersionStamping:
         version, or absent) and strict mode would accept incomplete
         provenance."""
         captured_users: list[str | None] = []
+        captured_timeouts: list[int | None] = []
 
         async def fake_exec(cmd, **kwargs):
             captured_users.append(kwargs.get("user"))
+            if cmd == ["asta", "--version"]:
+                captured_timeouts.append(kwargs.get("timeout"))
             res = MagicMock()
             res.success = cmd == ["asta", "--version"]
             res.stdout = "asta 0.17.0\n" if cmd == ["asta", "--version"] else ""
@@ -1028,6 +1031,7 @@ class TestVersionStamping:
             f"asta_version probe didn't forward user=appuser; "
             f"saw users={captured_users}"
         )
+        assert captured_timeouts == [30]
 
 
 def _fake_docker_inspect(image_id="sha256:fake", digest="", config_image=""):


### PR DESCRIPTION
## Summary

Raise the post-run `asta --version` provenance-probe timeout from 10s to 30s. A strict Cloud Batch eval completed agent work but discarded the sample when this housekeeping probe timed out under concurrent sandbox load.

Strict reproducibility remains enabled and still rejects a genuinely missing provenance stamp; this only gives the authoritative probe enough time to finish.

Tracked in allenai/gas2own#417.

## Validation

- `82 passed` in `tests/solvers/test_inspect_swe_solver.py`
- Black check
- Flake8
- `git diff --check`