### PR TITLE
inspect-swe: keep OpenAI client compatible with Inspect

### DIFF
--- a/scripts/smoke_solvers.sh
+++ b/scripts/smoke_solvers.sh
@@ -68,6 +68,13 @@ print("agent_baselines.solvers:", agent_baselines.solvers.__file__)
 print("astabench:", getattr(astabench, "__version__", "unknown"), astabench.__file__)
 print("inspect_ai:", getattr(inspect_ai, "__version__", "unknown"), inspect_ai.__file__)
 
+# Import the OpenAI provider, even when the selected eval model is Anthropic.
+# AstaBench task discovery imports this provider and therefore requires the
+# installed OpenAI client to expose every symbol expected by inspect_ai.
+from inspect_ai.model._providers.openai import OpenAIAPI  # noqa: F401, E402
+
+print("inspect_ai OpenAI provider: imports cleanly")
+
 # Lock-coherence gate. inspect_ai enforces a minimum Anthropic SDK version at
 # provider *construction* — not through package metadata — so an internally
 # incoherent lock (inspect_ai bumped, anthropic left stale) sails past both

--- a/solvers/inspect-swe/pyproject.toml
+++ b/solvers/inspect-swe/pyproject.toml
@@ -37,4 +37,11 @@ default-groups = ["astabench"]
 # the bridged-MCP serialization fix and the Anthropic bridge system-role
 # fix. Override astabench's pin so the resolver picks a newer inspect_ai.
 # Public APIs astabench uses are stable across 0.3.203..0.3.249.
-override-dependencies = ["inspect_ai>=0.3.249"]
+override-dependencies = [
+    "inspect_ai>=0.3.249",
+    # inspect-ai 0.3.249 imports AsyncBedrockOpenAI from the OpenAI client;
+    # that symbol was added in openai 2.40.0. Without this floor the
+    # AstaBench dependency graph resolves openai 2.33.0 and task discovery
+    # fails before an eval starts.
+    "openai>=2.40.0",
+]

--- a/solvers/inspect-swe/uv.lock
+++ b/solvers/inspect-swe/uv.lock
@@ -11,7 +11,10 @@ resolution-markers = [
 ]
 
 [manifest]
-overrides = [{ name = "inspect-ai", specifier = ">=0.3.249" }]
+overrides = [
+    { name = "inspect-ai", specifier = ">=0.3.249" },
+    { name = "openai", specifier = ">=2.40.0" },
+]
 
 [[package]]
 name = "agent-baselines-inspect-swe"
@@ -2296,7 +2299,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "2.33.0"
+version = "2.52.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2308,9 +2311,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f0/ee/d056c82f63c05f06baac0cffb4a90952d8274f90c49dfe244f20497b9bbd/openai-2.33.0.tar.gz", hash = "sha256:f850c435e2a4685bba3295bd54912dd26315d9c1b7733068186134d6e0599f9a", size = 693254, upload-time = "2026-04-28T14:04:42.428Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/5a/c45fa035cd72c70ebe67c6e079e3adf871492382634f69e3dff62c43597d/openai-2.52.0.tar.gz", hash = "sha256:7c736d592f81471ce1f734838390983c4d8c8aecff23dcd36e600a58e5032d9c", size = 1098876, upload-time = "2026-07-31T15:13:03.228Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7d/32/37734d769bc8b42e4938785313cc05aade6cb0fa72479d3220a0d61a4e78/openai-2.33.0-py3-none-any.whl", hash = "sha256:03ac37d70e8c9e3a8124214e3afa785e2cbc12e627fbd98177a086ef2fd87ad5", size = 1162695, upload-time = "2026-04-28T14:04:40.482Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/ac/ceb40c995df49533ad4dcff6c37f0d85cf14446a212363fc9d2f927e60b4/openai-2.52.0-py3-none-any.whl", hash = "sha256:f97e231d9a8fa69ab55897df1080f02d99913fb0a30e3ee56ea16a1eb6c2d434", size = 1659569, upload-time = "2026-07-31T15:13:01.145Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

- require `openai>=2.40.0` in the inspect-swe environment
- make the solver smoke test import Inspect's OpenAI provider

## Why

`inspect-ai==0.3.249` imports `AsyncBedrockOpenAI`, which first exists in
`openai==2.40.0`. The current lock resolves `openai==2.33.0`, so importing an
AstaBench Paper Finder task fails before evaluation starts. This was reproduced
by the one-question internal sanity smoke.

This changes only solver environment compatibility; it does not change any
AstaBench task or scorer.

## Validation

- `uv lock --project solvers/inspect-swe --check`
- exact provider import reports `inspect-ai 0.3.249`, `openai 2.52.0`
- `scripts/smoke_solvers.sh inspect-swe`
