### PR TITLE
inspect-swe: tolerate provenance probe contention

### DIFF
--- a/agent_baselines/solvers/inspect_swe/agent.py
+++ b/agent_baselines/solvers/inspect_swe/agent.py
@@ -25,10 +25,12 @@ AgentName = Literal[
 AstaPlugin = Literal["asta", "asta-preview"]
 
 # Provenance probes run after the agent, when a many-sample eval can have
-# substantial concurrent sandbox load. Ten seconds proved too short for the
-# otherwise-trivial ``asta --version`` command in Cloud Batch, causing strict
-# runs to discard completed samples solely because the stamp timed out.
-_PROVENANCE_PROBE_TIMEOUT = 30
+# substantial concurrent sandbox load. Thirty seconds proved too short for the
+# otherwise-trivial ``asta --version`` command in a 12-sample Cloud Batch run,
+# causing strict runs to discard completed samples solely because the stamp
+# timed out. Leave ample headroom for sandbox contention; this probe runs only
+# after the agent has finished and remains bounded.
+_PROVENANCE_PROBE_TIMEOUT = 120
 
 
 class AgentSpec(NamedTuple):

--- a/tests/solvers/test_inspect_swe_solver.py
+++ b/tests/solvers/test_inspect_swe_solver.py
@@ -1031,7 +1031,7 @@ class TestVersionStamping:
             f"asta_version probe didn't forward user=appuser; "
             f"saw users={captured_users}"
         )
-        assert captured_timeouts == [30]
+        assert captured_timeouts == [120]
 
 
 def _fake_docker_inspect(image_id="sha256:fake", digest="", config_image=""):


### PR DESCRIPTION
## Summary

Raise the bounded post-run provenance-probe timeout from 30s to 120s. A 12-sample strict Cloud Batch eval completed agent work but discarded the run when the housekeeping `asta --version` probe timed out under concurrent sandbox load.

Strict reproducibility remains enabled and still rejects missing provenance. This gives the authoritative runtime probe enough time to finish without weakening the requirement.

## Validation

- `82 passed` in `tests/solvers/test_inspect_swe_solver.py` via the `solvers/inspect-swe` environment
- Black check
- Flake8
- `git diff --check`
